### PR TITLE
Proposal: Replace wrapping_add with checked_add

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,7 +241,8 @@ impl<T> HandleMap<T> {
 
         debug_assert!(e.payload.is_none());
         e.payload = Some(value);
-        e.gen = e.gen.wrapping_add(1);
+        e.gen = e.gen.checked_add(1)
+            .expect("Generation overflowed");
 
         if e.gen == 0 {
             // Zero generation indicates an invalid handle.
@@ -299,9 +300,9 @@ impl<T> HandleMap<T> {
         }
         let update_gen = move |e: &mut Entry<T>| {
             if (e.gen & 1) == 0 {
-                e.gen = e.gen.wrapping_add(1);
+                e.gen = e.gen.checked_add(1).expect("Generation overflowed");
             } else {
-                e.gen = e.gen.wrapping_add(2);
+                e.gen = e.gen.checked_add(2).expect("Generation overflowed");
             }
             if e.gen == 0 {
                 e.gen = 1;
@@ -826,7 +827,7 @@ impl<T> HandleMap<T> {
 
     pub(crate) fn raw_remove(&mut self, index: usize) -> Option<T> {
         let mut e = &mut self.entries[index];
-        e.gen = e.gen.wrapping_add(1);
+        e.gen = e.gen.checked_add(1).expect("Generation overflowed");
         if e.gen == 0 {
             e.gen = 1;
         }


### PR DESCRIPTION
`u16` seems uncomfortably small a generation size for me to be sure that I won't overflow it by accident if I have, I dunno, a particle system that adds and removes lots of objects rapidly.  It looks like you use `wrapping_add` for all the generation increments, so it appears that a generation that gets maxed out will just wrap around, possibly making stale handles look alive again.  This PR (hopefully) replaces them all with `checked_add()` followed by an `expect()`.  This makes it a dynamically-checked error for a generation number to overflow.

Whether you want this is up to you, I just wanted to offer the suggestion.